### PR TITLE
Add model runner

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,6 +13,7 @@ class Config(object):
         db_host: str,
         reattempt_training_days: int,
         runner_process_count: int,
+        nats_host: str,
     ):
         self.db_user = db_user
         self.db_password = db_password
@@ -20,6 +21,7 @@ class Config(object):
         self.db_host = db_host
         self.reattempt_training_days = reattempt_training_days
         self.runner_process_count = runner_process_count
+        self.nats_host = nats_host
 
     def __str__(self):
         copy = self.__dict__.copy()
@@ -43,6 +45,7 @@ def load_config() -> Config:
             runner_process_count=get_int_environment_variable(
                 "PYTRANSITCAST_RUNNER_PROCESS_COUNT", 4
             ),
+            nats_host=os.environ["PYTRANSITCAST_NATS_HOST"],
         )
     except KeyError as e:
         log.warning(f"Unable to load configuration, missing parameters %{e}")

--- a/config.py
+++ b/config.py
@@ -4,17 +4,22 @@ import logging as log
 
 class Config(object):
     """Configuration parameters"""
-    def __init__(self,
-                 db_user: str,
-                 db_password: str,
-                 db_name: str,
-                 db_host: str,
-                 reattempt_training_days: int):
+
+    def __init__(
+        self,
+        db_user: str,
+        db_password: str,
+        db_name: str,
+        db_host: str,
+        reattempt_training_days: int,
+        runner_process_count: int,
+    ):
         self.db_user = db_user
         self.db_password = db_password
         self.db_name = db_name
         self.db_host = db_host
         self.reattempt_training_days = reattempt_training_days
+        self.runner_process_count = runner_process_count
 
     def __str__(self):
         copy = self.__dict__.copy()
@@ -27,11 +32,18 @@ def load_config() -> Config:
     Reads from variables
     PYTRANSITCAST_DB_USER, PYTRANSITCAST_DB_PASSWORD, PYTRANSITCASTR_DB_NAME and PYTRANSITCAST_DB_HOST"""
     try:
-        return Config(db_user=os.environ['PYTRANSITCAST_DB_USER'],
-                      db_password=os.environ['PYTRANSITCAST_DB_PASSWORD'],
-                      db_name=os.environ['PYTRANSITCAST_DB_NAME'],
-                      db_host=os.environ['PYTRANSITCAST_DB_HOST'],
-                      reattempt_training_days=get_int_environment_variable('PYTRANSITCAST_REATTEMPT_TRAINING_DAYS', 30))
+        return Config(
+            db_user=os.environ["PYTRANSITCAST_DB_USER"],
+            db_password=os.environ["PYTRANSITCAST_DB_PASSWORD"],
+            db_name=os.environ["PYTRANSITCAST_DB_NAME"],
+            db_host=os.environ["PYTRANSITCAST_DB_HOST"],
+            reattempt_training_days=get_int_environment_variable(
+                "PYTRANSITCAST_REATTEMPT_TRAINING_DAYS", 30
+            ),
+            runner_process_count=get_int_environment_variable(
+                "PYTRANSITCAST_RUNNER_PROCESS_COUNT", 4
+            ),
+        )
     except KeyError as e:
         log.warning(f"Unable to load configuration, missing parameters %{e}")
         exit(1)

--- a/config.py
+++ b/config.py
@@ -14,6 +14,7 @@ class Config(object):
         reattempt_training_days: int,
         runner_process_count: int,
         nats_host: str,
+        rmse_margin: int,
     ):
         self.db_user = db_user
         self.db_password = db_password
@@ -22,6 +23,7 @@ class Config(object):
         self.reattempt_training_days = reattempt_training_days
         self.runner_process_count = runner_process_count
         self.nats_host = nats_host
+        self.rmse_margin = rmse_margin
 
     def __str__(self):
         copy = self.__dict__.copy()
@@ -46,6 +48,7 @@ def load_config() -> Config:
                 "PYTRANSITCAST_RUNNER_PROCESS_COUNT", 4
             ),
             nats_host=os.environ["PYTRANSITCAST_NATS_HOST"],
+            rmse_margin=get_int_environment_variable("PYTRANSITCAST_RMSE_MARGIN", 0),
         )
     except KeyError as e:
         log.warning(f"Unable to load configuration, missing parameters %{e}")

--- a/main.py
+++ b/main.py
@@ -1,21 +1,21 @@
+import argparse
 import warnings
 import logging as log
 import datetime
 import data_loader
 import model_trainer
+import model_runner
 from config import load_config
 
 # Ignore pandas.Int64Index warnings internal to xgboost.
-warnings.filterwarnings('ignore', 'pandas.Int64Index', FutureWarning, 'xgboost')
+warnings.filterwarnings("ignore", "pandas.Int64Index", FutureWarning, "xgboost")
 
-log.basicConfig(level=log.INFO, format='%(asctime)s:%(levelname)s:%(message)s')
+log.basicConfig(level=log.INFO, format="%(asctime)s:%(levelname)s:%(message)s")
 
 
-def main():
-    config = load_config()
-    log.info(f"Using config: {config}")
-
-    start_date = datetime.datetime.strptime('2021-01-01', '%Y-%m-%d')
+def train(config):
+    conn = data_loader.connect(config)
+    start_date = datetime.datetime.strptime("2021-01-01", "%Y-%m-%d")
     now = datetime.datetime.now()
     reattempt_date = now - datetime.timedelta(days=config.reattempt_training_days)
     end_date = now.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -24,5 +24,28 @@ def main():
     model_trainer.train_pending_models(conn, start_date, end_date, reattempt_date)
 
 
+def infer(config):
+    conn = data_loader.connect(config)
+    model_runner.start_runner(
+        conn, config.runner_process_count, config.nats_host, config.rmse_margin
+    )
+
+
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Run or train pytransitcast ML Models")
+
+    parser.add_argument(
+        "--mode",
+        dest="mode",
+        choices=["infer", "train"],
+        required=True,
+        help="Whether to train models or run the inference server. Must be one of 'train' or 'infer'",
+    )
+
+    args = parser.parse_args()
+
+    config = load_config()
+    log.info(f"Using config: {config}")
+
+    if args.mode == "train":
+        train()

--- a/main.py
+++ b/main.py
@@ -48,4 +48,6 @@ if __name__ == "__main__":
     log.info(f"Using config: {config}")
 
     if args.mode == "train":
-        train()
+        train(config)
+    if args.mode == "infer":
+        infer(config)

--- a/model_runner.py
+++ b/model_runner.py
@@ -1,0 +1,99 @@
+from typing import NamedTuple
+import datetime
+import logging as log
+import model_records
+import os
+import queue
+import xgboost as xgb
+import numpy as np
+import multiprocessing as mp
+
+
+class InferenceRequest(NamedTuple):
+    request_id: str
+    timestamp: int
+    features: np.ndarray
+
+
+class Job(NamedTuple):
+    model: xgb.XGBRegressor
+    inference_request: InferenceRequest
+
+
+class ModelRunner:
+    """Starts worker subprocesses, handles incoming jobs."""
+
+    def __init__(self, conn, thread_count: int):
+        self.conn = conn
+        self.loaded_models = {}
+        self.queue = mp.Queue()
+
+        self.pool = mp.Pool(
+            thread_count,
+            queue_handler,
+            (self.queue,),
+        )
+
+    def load_relevant_models(self):
+        # TODO: only load relevant models
+        # By setting this to tomorrow and setting train flag to false we get all models that are currently trained
+        tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+        models = model_records.get_current_models(self.conn, tomorrow, False)  # type: ignore
+        for model in models:
+
+            loaded = xgb.XGBRegressor()
+            model_bytes = bytearray(model.model_blob)
+            loaded.load_model(model_bytes)
+            self.loaded_models[str(model.ml_model_id)] = loaded
+        log.info(f"Loaded {len(self.loaded_models)} models")
+
+    def add_job(self, model_id: str, request: InferenceRequest):
+        try:
+            loaded_model = self.loaded_models[model_id]
+        except Exception as e:
+            log.warn(f"Model {model_id} couldn't be loaded: {e}")
+            return
+        self.queue.put(Job(loaded_model, request))
+
+    def tear_down(self):
+        log.info("Tearing down")
+        self.pool.close()
+        self.pool.join()
+
+
+def queue_handler(queue: queue.Queue):
+    """The loop that runs in the subprocess"""
+    log.info(f"Launching thread {os.getpid()}")
+    while True:
+        job = queue.get()
+        log.info(f"Thread {os.getpid()} starting new job")
+        infer(job)
+
+
+def infer(job: Job):
+    """The method run by the subprocess which does the correct inference"""
+
+    try:
+        result = job.model.predict(job.inference_request.features)
+        print(result)
+    except Exception as e:
+        log.error(f"Couldn't infer: {e}")
+
+
+def start_runner(conn, runner_process_count: int):
+    runner = ModelRunner(conn, runner_process_count)
+
+    try:
+        runner.load_relevant_models()
+        for i in range(0, 415):
+            runner.add_job(
+                str(i),
+                InferenceRequest(
+                    "0", 0, np.array([[5, 1, 12, 20, 50, 0, 0, 0, 100, 40, 0, 0]])
+                ),
+            )
+    except Exception as e:
+        log.error(f"An unhandled error has occured: {e}")
+    finally:
+        log.info(f"Closing threads...")
+        runner.tear_down()

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,17 @@
 from setuptools import setup, find_packages
+
 setup(
     name="updatedist",
     version="0.1",
     packages=find_packages(),
     install_requires=[
-        'xgboost==1.5.2',
-        'pandas==1.1.5',
-        'holidays==0.13',
-        'numpy==1.19.5',
-        'scikit_learn==0.24.2',
-        'psycopg2-binary==2.9.3'
-    ]
+        "xgboost==1.5.2",
+        "pandas==1.1.5",
+        "holidays==0.13",
+        "numpy==1.19.5",
+        "scipy==1.8.1",
+        "scikit_learn==0.24.2",
+        "psycopg2-binary==2.9.3",
+        "nats-py==2.1.3",
+    ],
 )


### PR DESCRIPTION
This PR adds an inference server that loads all models with a certain RMSE into memory, launches a NATS client that listens for inference requests, processes those requests using a process pool, and sends the inference results back via a different NATS subscription.

There is likely some documentation to add regarding the data structure of the NATS messages, as well as the environment variables, but I'm not sure how/where we want to put that documentation.

There are some tests to add as well.